### PR TITLE
Added Ubuntu instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,9 @@ hggit = [path-to]/hg-git/hggit</pre>
 
 	<h3>Ubuntu Specific</h3>
 	<p>Add the <a href=https://launchpad.net/~mercurial-ppa">Mercurial PPA</a></p>
-	<pre>$ sudo add-apt-repository
+	<pre>$ sudo add-apt-repository ppa:mercurial-ppa/releases
 $ sudo apt-get update
-$ sudo apt-get install mercurial-ppa</pre>
+$ sudo apt-get install mercurial-git</pre>
 
 	<p>Modify your <code>~/.hgrc</code> file</p>
 	<pre>[extenstion]


### PR DESCRIPTION
I added some Ubuntu specific instructions. The main reasons were because Debian/Ubuntu use git instead of hggit in ~/.hgrc and the current Ubuntu version is too old and has bugs which prevent it from working with Heroku.
