### PR TITLE
Make Installation section self-contained and clearer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,27 +94,50 @@ $ hg push</pre>
 
       <div class='section'>
         <div class="title">Installing</div>
-        <h3>The easy way:</h3>
+        <h3>Installing Hg-Git the easy way:</h3>
         <p>
-          Run <code>easy_install hg-git</code>, then add make sure the
+          First, make sure that you have a working C compiler on your
+          system. On Windows, one option is the
+          free <a href="http://www.microsoft.com/express/Downloads/#2008-Visual-CPP">Microsoft
+          Visual C++</a>. (Be sure to install the 2008 version for
+          compatibility reasons.) On Debian-style Linux,
+          run <code>apt-get install python-dev</code>.
+        </p>                
+        <p>
+          Secondly, run <code>easy_install hg-git</code>. If you don't
+          have easy_install available, you can get it as part of
+          Python's 
+          <a href="http://pypi.python.org/pypi/setuptools">setuptools</a>
+          package.
+        </p>
+        
+        <p>
+          Lastly, make sure the
           following is in your <code>~/.hgrc</code>:
         </p>
         <pre>[extensions]
 hgext.bookmarks =
 hggit = </pre>
         <p>
-          ...and that's it! Note that this requires having working C
-          compilers on your system.
+          ...and that's it! 
         </p>
 
-        <h3>The more involved way</h3>
+        <h3>Installing Hg-Git manually</h3>
         <p>
-          First, install version 0.8.0 or newer
-          of <a href="http://pypi.python.org/pypi/dulwich">dulwich</a>. You
-          can do <code>easy_install 'dulwich>=0.8.0'</code> if you
-          have setuptools
-          installed. Clone <a href="http://bitbucket.org/durin42/hg-git">this
-          repository</a> somewhere, then make the 'extensions' section in your
+          Use this method if you'd like to install a clone of the Hg-Git
+          repository rather than a static package, or if you'd like to
+          install Hg-Git in a location you choose yourself.
+        </p>
+        <p>
+          First, install version 0.8.0 or newer of 
+          <a href="http://pypi.python.org/pypi/dulwich">Dulwich</a>. 
+          You can do 
+          <code>easy_install 'dulwich>=0.8.0'</code> if you have 
+          <a href="http://pypi.python.org/pypi/setuptools">setuptools</a>
+          installed. Next, clone 
+          <a href="http://bitbucket.org/durin42/hg-git">the Hg-Git
+            repository</a> 
+          somewhere. Lastly, make the 'extensions' section in your
           '<code>~/.hgrc</code>' file look something like this:
         </p>
 
@@ -132,22 +155,13 @@ hggit = [path-to]/hg-git/hggit</pre>
       <div class='section'>
         <div class="title">Dependencies</div>
         <p>
-          This plugin is implemented entirely in Python - there
-          are <strong>no Git binary dependencies</strong>, you do not
-          need to have Git installed on your system. There are in fact
-          no external dependencies currently other than Mercurial and
-          Dulwich. The plugin is known to work on Mercurial 1.7, and
-          is basically functional (with a couple of bugs) against hg
-          1.8 and 1.9.
-        </p>
-        <p>
-          Note that Dulwich has C extensions, so it requires a C
-          compiler when installing via easy_install.  On Windows, one
-          option is the
-          free <a href="http://www.microsoft.com/express/Downloads/#2008-Visual-CPP">Microsoft
-          Visual C++</a>.  Be sure to install the 2008 version for
-          compatibility reasons.  On debian-style linux,
-          run: <code>apt-get install python-dev.</code>
+          This plugin is known to work on Mercurial 1.7, and is
+          basically functional (with a couple of bugs) against hg 1.8
+          and 1.9. It also needs Dulwich version 0.8.0 or later; Dulwich
+          is a pure-Python implementation of the Git file formats and
+          protocols. There are <strong>no Git binary
+            dependencies</strong>: you do not need to have Git installed
+          on your system. 
         </p>
       </div>
 


### PR DESCRIPTION
- Dulwich requires a C compiler at installation time; this is now
  mentioned in "Installation" instead of further down in "Dependencies".
  This leaves "Dependencies" naming the runtime dependencies, and only
  those.
- "Installation" now mentions where to get easy_install/setuptools, for
  those that don't have it.
- "Installation" now explains the difference/advantage of manual
  install: that one runs Hg-Git from a repository clone rather than from
  a static package.
- "Dependencies" now mentions what Dulwich _is_, for the curious.
