### PR TITLE
Changed link for Visual C++ 2008

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ $ hg push</pre>
         <p>
           First, make sure that you have a working C compiler on your
           system. On Windows, one option is the
-          free <a href="http://www.microsoft.com/express/Downloads/#2008-Visual-CPP">Microsoft
+          free <a href="http://msdn.microsoft.com/en-us/express/future/bb421473">Microsoft
           Visual C++</a>. (Be sure to install the 2008 version for
           compatibility reasons.) On Debian-style Linux,
           run <code>apt-get install python-dev</code>.


### PR DESCRIPTION
Changed the link so other Windows users don't have to hunt to try to find Visual C++ 2008, as the previous link was of no assistance.
