### PR TITLE
Made instructions clearer

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
         <div class='section'>
           <div class="title">Commands</div>
 
+          <h3>Clone a Git repository</h3>
+
           <p>
             You can clone a Git repository from Mercurial by
             running <code>hg clone [url]</code>. It will create a
@@ -58,6 +60,10 @@
 
       <pre>hg clone git://github.com/schacon/munger.git</pre>
 
+          <p>And you're off!</p>
+
+          <h3>Push an existing Hg repository to Git</h3>
+
         <p>
           If you are starting from an existing Mercurial repository,
           you have to setup a Git repository somewhere that you have
@@ -66,21 +72,27 @@
         </p>
 
         <pre>$ cd mercurial-repo
-$ hg bookmark -r default master # so a ref gets created
-$ hg push git+ssh://git@github.com/schacon/some-repo.git
-$ hg push</pre>
+$ hg bookmark -r default master # so a ref gets created</pre>
+
+        <p>
+          To avoid specifying the repo path when you push and pull,
+          edit <code>.hg/hgrc</code> and add:
+        </p>
+
+        <pre>[paths]
+default = git+ssh://git@github.com/schacon/some-repo.git</pre>
+
+        <p>
+          See
+          <a href="https://www.selenic.com/mercurial/hgrc.5.html#paths">
+          the Mercurial docs</a> for more detail on path settings.
+        </p>
+
+        <pre>$ hg push</pre>
 
         <p>
           This will convert all our Mercurial data into Git objects
-          and push them up to the Git server. You can also put that
-          path in the <code>[paths]</code> section of .hg/hgrc and
-          then push to it by name.
-        </p>
-
-        <p>
-          Now that you have a Mercurial repository that can push/pull
-          to/from a Git repository, you can get updates
-          with <code>hg pull</code>.
+          and push them up to the Git server.
         </p>
 
       <pre>$ hg pull</pre>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             Eg:
           </p>
 
-          <pre>hg clone git://github.com/schacon/munger.git</pre>
+          <pre>hg clone git://github.com/schacon/some-repo.git</pre>
 
           <p>
             Like with normal <code>hg clone</code>, you can optionally

--- a/index.html
+++ b/index.html
@@ -49,18 +49,15 @@
           <h3>Clone a Git repository</h3>
 
           <p>
-            You can clone a Git repository from Mercurial by
-            running <code>hg clone [url]</code>. It will create a
-            directory with the same name as the last path component. For
-            example, if you were to run <code>hg clone
-              git://github.com/schacon/munger.git</code> it would clone
-            the repository down into the directory 'munger.git', then
-            convert it to a Mercurial repository for you.
+            Eg:
           </p>
 
-      <pre>hg clone git://github.com/schacon/munger.git</pre>
+          <pre>hg clone git://github.com/schacon/munger.git</pre>
 
-          <p>And you're off!</p>
+          <p>
+            Like with normal <code>hg clone</code>, you can optionally
+            specify a destination directory.
+          </p>
 
           <h3>Push an existing Hg repository to Git</h3>
 

--- a/index.html
+++ b/index.html
@@ -65,9 +65,9 @@
           from within your project. For example:
         </p>
 
-        <pre>$ cd hg-git # (a Mercurial repository)
-$ hg bookmark -r default master # make a bookmark of master for default, so a ref gets created
-$ hg push git+ssh://git@github.com/schacon/hg-git.git
+        <pre>$ cd mercurial-repo
+$ hg bookmark -r default master # so a ref gets created
+$ hg push git+ssh://git@github.com/schacon/some-repo.git
 $ hg push</pre>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -48,10 +48,6 @@
 
           <h3>Clone a Git repository</h3>
 
-          <p>
-            Eg:
-          </p>
-
           <pre>hg clone git://github.com/schacon/some-repo.git</pre>
 
           <p>
@@ -60,13 +56,6 @@
           </p>
 
           <h3>Push an existing Hg repository to Git</h3>
-
-        <p>
-          If you are starting from an existing Mercurial repository,
-          you have to setup a Git repository somewhere that you have
-          push access to, and then run <code>hg push [path]</code>
-          from within your project. For example:
-        </p>
 
         <pre>$ cd mercurial-repo
 $ hg bookmark -r default master # so a ref gets created</pre>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ default = git+ssh://git@github.com/schacon/some-repo.git</pre>
         <pre>$ hg push</pre>
 
         <p>
-          This will convert all our Mercurial data into Git objects
+          This will convert all Mercurial data into Git objects
           and push them up to the Git server.
         </p>
 


### PR DESCRIPTION
This tries to make the docs clearer in a few ways:

1. Adds explicit instructions for setting up `[paths]` and assumes that most people will want to do this.
1. Adds headings to more clearly differentiate between cloning and pushing an existing repo.
1. Trims some text that should be obvious to anyone using this. Basic hg usage is probably out of scope.
1. Shuffles things around a bit and dedupes for better general organization.

# Before
![before](https://cloud.githubusercontent.com/assets/354611/11972116/76587f02-a915-11e5-9355-b572f619c85e.png)

# After
![after](https://cloud.githubusercontent.com/assets/354611/11972127/85831a3c-a915-11e5-9478-a883d418ae46.png)
