### PR TITLE
Update links and maintainer

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ default = git+ssh://git@github.com/schacon/some-repo.git</pre>
         </p>
         
         <p>
-          Alternatively, on Windows, <a href="http://tortoisehg.bitbucket.org/">TortoiseHg</a>
+          Alternatively, on Windows, <a href="https://tortoisehg.bitbucket.io">TortoiseHg</a>
           comes with hg-git (and Dulwich), though it 
           <a href="http://tortoisehg.readthedocs.org/en/latest/nonhg.html#hg-git-git">still needs to be enabled</a>
           as shown below (or through the TortoiseHg settings).

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ hggit = [path-to]/hg-git/hggit</pre>
           Source available via
           <a href="https://bitbucket.org/durin42/hg-git">hg</a>
           (canonical repo) or
-          <a href="http://github.com/schacon/hg-git">git</a> (mirror
+          <a href="https://github.com/schacon/hg-git">git</a> (mirror
           of hg). Patches preferred via email to
           the <a href="http://groups.google.com/group/hg-git">hg-git
           mailing list</a>.
@@ -194,7 +194,7 @@ hggit = [path-to]/hg-git/hggit</pre>
     <div class="span-21">
       <div id="bottom">
         This plugin was originally developed by the folks
-        at <a href="http://github.com">GitHub</a>, and is currently
+        at <a href="https://github.com">GitHub</a>, and is currently
         maintained by Augie Fackler.
       </div>
     </div>
@@ -206,7 +206,7 @@ hggit = [path-to]/hg-git/hggit</pre>
         </div>
       </div>
       <div class="fork span-7">
-        This website is <a href="http://github.com/hg-git/hg-git.github.com">open source</a>.
+        This website is <a href="https://github.com/hg-git/hg-git.github.com">open source</a>.
         Please help us by forking the project and adding to it.
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@ hggit = </pre>
           <code>easy_install 'dulwich>=0.8.0'</code> if you have 
           <a href="https://pypi.org/project/setuptools/">setuptools</a>
           installed. Next, clone 
-          <a href="http://bitbucket.org/durin42/hg-git">the Hg-Git
+          <a href="https://bitbucket.org/durin42/hg-git">the Hg-Git
             repository</a> 
           somewhere. Lastly, make the 'extensions' section in your
           '<code>~/.hgrc</code>' file look something like this:
@@ -182,7 +182,7 @@ hggit = [path-to]/hg-git/hggit</pre>
         <div class="title">Sources</div>
         <p>
           Source available via
-          <a href="http://bitbucket.org/durin42/hg-git">hg</a>
+          <a href="https://bitbucket.org/durin42/hg-git">hg</a>
           (canonical repo) or
           <a href="http://github.com/schacon/hg-git">git</a> (mirror
           of hg). Patches preferred via email to

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ default = git+ssh://git@github.com/schacon/some-repo.git</pre>
 
         <p>
           See
-          <a href="https://www.selenic.com/mercurial/hgrc.5.html#paths">
+          <a href="https://www.mercurial-scm.org/doc/hgrc.5.html#paths">
           the Mercurial docs</a> for more detail on path settings.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@ hggit = [path-to]/hg-git/hggit</pre>
           (canonical repo) or
           <a href="https://github.com/schacon/hg-git">git</a> (mirror
           of hg). Patches preferred via email to
-          the <a href="http://groups.google.com/group/hg-git">hg-git
+          the <a href="https://groups.google.com/group/hg-git">hg-git
           mailing list</a>.
         </p>
       </div>
@@ -202,7 +202,7 @@ hggit = [path-to]/hg-git/hggit</pre>
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://groups.google.com/group/hg-git/">Google Group</a>
+          <a href="https://groups.google.com/group/hg-git">Google Group</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ default = git+ssh://git@github.com/schacon/some-repo.git</pre>
           Secondly, run <code>easy_install hg-git</code>. If you don't
           have easy_install available, you can get it as part of
           Python's 
-          <a href="http://pypi.python.org/pypi/setuptools">setuptools</a>
+          <a href="https://pypi.org/project/setuptools/">setuptools</a>
           package.
         </p>
         
@@ -135,10 +135,10 @@ hggit = </pre>
         </p>
         <p>
           First, install version 0.8.0 or newer of 
-          <a href="http://pypi.python.org/pypi/dulwich">Dulwich</a>. 
+          <a href="https://pypi.org/project/dulwich/">Dulwich</a>. 
           You can do 
           <code>easy_install 'dulwich>=0.8.0'</code> if you have 
-          <a href="http://pypi.python.org/pypi/setuptools">setuptools</a>
+          <a href="https://pypi.org/project/setuptools/">setuptools</a>
           installed. Next, clone 
           <a href="http://bitbucket.org/durin42/hg-git">the Hg-Git
             repository</a> 

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ default = git+ssh://git@github.com/schacon/some-repo.git</pre>
         <p>
           Alternatively, on Windows, <a href="https://tortoisehg.bitbucket.io">TortoiseHg</a>
           comes with hg-git (and Dulwich), though it 
-          <a href="http://tortoisehg.readthedocs.org/en/latest/nonhg.html#hg-git-git">still needs to be enabled</a>
+          <a href="https://tortoisehg.readthedocs.io/en/latest/nonhg.html#hg-git-git">still needs to be enabled</a>
           as shown below (or through the TortoiseHg settings).
         </p>
         

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@ hggit = [path-to]/hg-git/hggit</pre>
       <div id="bottom">
         This plugin was originally developed by the folks
         at <a href="https://github.com">GitHub</a>, and is currently
-        maintained by Augie Fackler.
+        maintained by Kevin Bullock.
       </div>
     </div>
 


### PR DESCRIPTION
This pull request refreshes some old links in hg-git's webpage, indicating up-to-date websites, possibly in using ssl.

Moreover, the final commit replaces the name of the old maintainer (Augie Fackler) with the current one (Kevin Bullock).

This is a follw-up to https://bitbucket.org/durin42/hg-git/issues/261
