### PR TITLE
Homepage: mention the new canonical repo on heptapod

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,11 +181,9 @@ hggit = [path-to]/hg-git/hggit</pre>
       <div class='section'>
         <div class="title">Sources</div>
         <p>
-          Source available via
-          <a href="https://foss.heptapod.net/mercurial/hg-git">hg</a>
-          (canonical repo) or
-          <a href="https://github.com/schacon/hg-git">git</a> (mirror
-          of hg). Patches preferred via email to
+          Source available at
+          <a href="https://foss.heptapod.net/mercurial/hg-git">https://foss.heptapod.net/mercurial/hg-git</a>.
+          Patches preferred via email to
           the <a href="https://groups.google.com/group/hg-git">hg-git
           mailing list</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -163,8 +163,8 @@ hggit = [path-to]/hg-git/hggit</pre>
           Different versions of hg-git are known to work with different
           versions of Mercurial. For the most accurate info, go to
           <a href="https://foss.heptapod.net/mercurial/hg-git">the source
-          on Heptapod</a>, click the dropdown menu that says "default",
-          click the "Tags" tab, select the version you've installed, and
+          on Heptapod</a>, click the dropdown menu that says "branch/default",
+          select the tag corresponding to the version you've installed, and
           click on the file "Makefile". There's a line that starts with
           "all-version-tests" which lists the versions of Mercurial
           known to work.

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@ hggit = </pre>
           <code>easy_install 'dulwich>=0.8.0'</code> if you have 
           <a href="https://pypi.org/project/setuptools/">setuptools</a>
           installed. Next, clone 
-          <a href="https://bitbucket.org/durin42/hg-git">the Hg-Git
+          <a href="https://foss.heptapod.net/mercurial/hg-git">the Hg-Git
             repository</a> 
           somewhere. Lastly, make the 'extensions' section in your
           '<code>~/.hgrc</code>' file look something like this:
@@ -162,8 +162,8 @@ hggit = [path-to]/hg-git/hggit</pre>
         <p>
           Different versions of hg-git are known to work with different
           versions of Mercurial. For the most accurate info, go to
-          <a href="https://bitbucket.org/durin42/hg-git/src">the source
-          on bitbucket</a>, click the dropdown menu that says "default",
+          <a href="https://foss.heptapod.net/mercurial/hg-git">the source
+          on Heptapod</a>, click the dropdown menu that says "default",
           click the "Tags" tab, select the version you've installed, and
           click on the file "Makefile". There's a line that starts with
           "all-version-tests" which lists the versions of Mercurial
@@ -182,7 +182,7 @@ hggit = [path-to]/hg-git/hggit</pre>
         <div class="title">Sources</div>
         <p>
           Source available via
-          <a href="https://bitbucket.org/durin42/hg-git">hg</a>
+          <a href="https://foss.heptapod.net/mercurial/hg-git">hg</a>
           (canonical repo) or
           <a href="https://github.com/schacon/hg-git">git</a> (mirror
           of hg). Patches preferred via email to


### PR DESCRIPTION
Some time ago the canonical repo for hg-git was migrated to Heptapod.

This PR updates the links (from https://bitbucket.org/durin42/hg-git to https://foss.heptapod.net/mercurial/hg-git) and removes a link to a unmaintained Github mirror (see https://github.com/schacon/hg-git/issues/341).